### PR TITLE
tools conversion from ifconfig to ip

### DIFF
--- a/programs/buildkernel/ocfs2_nicdown.py
+++ b/programs/buildkernel/ocfs2_nicdown.py
@@ -67,4 +67,4 @@ o2tf.printlog('ocfs2_nicdown: Bringing interface %s down' % NIC,
 	logfile,
 	0,
 	'')
-os.system('/sbin/ifconfig %s down' % NIC)
+os.system('/sbin/ip link set %s down' % NIC)

--- a/programs/python_common/multiple_run.sh
+++ b/programs/python_common/multiple_run.sh
@@ -34,7 +34,7 @@ ECHO="`which echo` -e"
 O2CLUSTER="`which o2cluster`"
 
 SUDO="`which sudo` -u root"
-IFCONFIG_BIN="`which ifconfig`"
+IP_BIN="`which ip`"
 SED=`which sed`
 
 REMOTE_MOUNT_BIN="${BINDIR}/remote_mount.py"
@@ -208,7 +208,7 @@ f_setup()
         fi
 
 	if [ ! -z "${INTERFACE}" ]; then
-		${IFCONFIG_BIN} ${INTERFACE} >/dev/null 2>&1 || {
+		${IP_BIN} addr show ${INTERFACE} >/dev/null 2>&1 || {
 			echo "Invalid NIC";
 			f_usage;
 		}

--- a/programs/python_common/o2tf.py
+++ b/programs/python_common/o2tf.py
@@ -336,16 +336,18 @@ def GetOcfs2NIC(DEBUGON, Cluster):
 				print('GetOcfs2NIC: IPAddress = %s' % \
 					IPAddress)
 			fd.close()
-			out = os.popen('/sbin/ifconfig | awk \' \
-				/^eth/{eth=$1}/inet addr:'+ 
-				IPAddress+'/{print eth;exit}\'')
-			NIC=out.read().strip('\n')
+			out = os.popen('ip addr show | awk \' \
+					/eth[[:digit:]]+:/{eth=$2}/inet '+
+					IPAddress+'/{print eth;exit}\' | tr -d :')
+
+
+			NIC=string.strip(out.read(), '\n')
 			out.close()
 			if not NIC:
-				out = os.popen('/sbin/ifconfig | awk \' \
-					/^bond/{eth=$1}/inet addr:'+
-					IPAddress+'/{print eth;exit}\'')
-				NIC=out.read().strip('\n')
+				out = os.popen('ip addr show | awk \' \
+						/bond[[:ditit:]]+/{eth=$2}/inet '+
+						IPAddress+'/{print eth;exit}\'  | tr -d :')
+				NIC=string.strip(out.read(), '\n')
 				out.close()
 
 			if DEBUGON:

--- a/programs/reflink_tests/multi_reflink_test_run.sh
+++ b/programs/reflink_tests/multi_reflink_test_run.sh
@@ -61,7 +61,7 @@ LABELNAME="ocfs2-multi-refcount-tests-`uname -m`"
 WORK_PLACE_DIRENT=ocfs2-multi-refcount-tests
 WORK_PLACE=
 MULTI_REFLINK_TEST_BIN="${BINDIR}/multi_reflink_test"
-IFCONFIG_BIN="`which sudo` -u root `which ifconfig`"
+IP_BIN="`which sudo` -u root `which ip`"
 
 DEFAULT_LOG_DIR=${O2TDIR}/log
 LOG_DIR=
@@ -179,7 +179,7 @@ ${MOUNT_POINT}`"
 	fi
 
 	if [ ! -z "${INTERFACE}" ]; then
-		${IFCONFIG_BIN} ${INTERFACE} >/dev/null 2>&1 || {
+		${IP_BIN} addr show ${INTERFACE} >/dev/null 2>&1 || {
 			echo "Invalid NIC";
 			f_usage;
 		} 

--- a/programs/splice/splice_test.py
+++ b/programs/splice/splice_test.py
@@ -129,12 +129,12 @@ if __name__=='__main__':
 		type='int',
 		help='Number of times the test will be repeated.')
 #
-        parser.add_option('-D',
-                '--debug',
-                action="store_true",
-                dest='debug',
-                default=False,
-                help='Turn the debug option on. Default=False.')
+	parser.add_option('-D',
+			'--debug',
+			action="store_true",
+			dest='debug',
+			default=False,
+			help='Turn the debug option on. Default=False.')
 #
 	parser.add_option('-l',
 		'--logfile',

--- a/programs/xattr_tests/xattr-multi-run.sh
+++ b/programs/xattr_tests/xattr-multi-run.sh
@@ -58,7 +58,7 @@ REMOTE_UMOUNT_BIN="${BINDIR}/remote_umount.py"
 MKFS_BIN="`which sudo` -u root `which mkfs.ocfs2`"
 CHMOD_BIN="`which sudo` -u root `which chmod`"
 CHOWN_BIN="`which sudo` -u root `which chown`"
-IFCONFIG_BIN="`which sudo` -u root `which ifconfig`"
+IP_BIN="`which sudo` -u root `which ip`"
 
 XATTR_TEST_BIN="${BINDIR}/xattr-multi-test"
 
@@ -209,7 +209,7 @@ f_setup()
 	fi
 
 	if [ ! -z "${INTERFACE}" ]; then
-		${IFCONFIG_BIN} ${INTERFACE} >/dev/null 2>&1 || {
+		${IP_BIN} addr show ${INTERFACE} >/dev/null 2>&1 || {
 			echo "Invalid NIC";
 			f_usage;
 		} 


### PR DESCRIPTION
ifconfig, as a deprecated tool, has been excluded from many linux distributions default package set.
And ip could perfectly take its place, and it's highly recommended.